### PR TITLE
【Task. 7-4 記事作成の実装】

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,2 +1,0 @@
-class Api::V1::ApiController < ApplicationController
-end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,5 +9,16 @@ module Api::V1
       article = Article.find(params[:id])
       render json: article
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,11 +1,13 @@
-class Api::V1::ArticlesController < ApplicationController
-  def index
-    articles = Article.all
-    render json: articles
-  end
+module Api::V1
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.all
+      render json: articles
+    end
 
-  def show
-    article = Article.find(params[:id])
-    render json: article
+    def show
+      article = Article.find(params[:id])
+      render json: article
+    end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::BaseApiController < ApplicationController
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  # current_user のダミーコード
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -1,6 +1,7 @@
-# Copy from https://github.com/onk/onkcop/blob/master/config/rspec.yml
-
 require: "rubocop-rspec"
+
+RSpec/AnyInstance:
+  Enabled: false
 
 # 日本語だと「〜の場合」になるので suffix でないと対応できない
 RSpec/ContextWording:
@@ -22,7 +23,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 8
+  Enabled: false
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ
@@ -47,7 +48,7 @@ RSpec/InstanceVariable:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  AggregateFailuresByDefault: true
+  Max: 4
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -16,7 +16,7 @@
 FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
-    body { Faker::Lorem.sentences }
+    body { Faker::Lorem.sentence }
     user
   end
 end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -23,15 +23,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /users/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定した id のユーザーが存在する場合" do
+    context "指定した id の記事が存在する場合" do
       let(:article) { create(:article) }
       let(:article_id) { article.id }
 
-      it "任意のユーザーの値が取得できる" do
+      it "任意の記事が取得できる" do
         subject
 
         res = JSON.parse(response.body)
-
         aggregate_failures do
           expect(response).to have_http_status(:ok)
           expect(res["id"]).to eq article.id
@@ -43,11 +42,30 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
 
-    context "指定した id のユーザーが存在しない場合" do
+    context "指定した id の記事が存在しない場合" do
       let(:article_id) { 10000 }
 
-      it "ユーザーが見つからない" do
+      it "記事が見つからない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "記事のレコードが作成できる" do
+      aggregate_failures do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
       end
     end
   end


### PR DESCRIPTION
## 概要
- 記事の作成機能とテストを実装

## 補足
- current_user のダミーメソッドを定義
- 記事に関する FactoryBot のダミーデーターに誤りがあったので修正
- rubocop の判定を緩和
- `article_controller`の継承元、及び名前等の変更 