### PR TITLE
【Task. 7-6 記事削除の実装】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -20,6 +20,11 @@ module Api::V1
       article.update!(article_params)
     end
 
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
+    end
+
     private
 
       def article_params

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -68,33 +68,33 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+  end
 
-    describe "PATCH /api/v1/articles/:id" do
-      subject { patch(api_v1_article_path(article.id), params: params) }
+  describe "PATCH /api/v1/articles/:id" do
+    subject { patch(api_v1_article_path(article.id), params: params) }
 
-      let(:params) { { article: attributes_for(:article) } }
-      let(:current_user) { create(:user) }
-      before do
-        allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+    before do
+      allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)
+    end
+
+    context "自分の記事を更新するとき" do
+      let(:article) { create(:article, user: current_user) }
+
+      it "任意の記事の更新ができる" do
+        expect { subject }.to change { Article.find(article.id).title }.from(article.title).to(params[:article][:title]) &
+                              change { Article.find(article.id).body }.from(article.body).to(params[:article][:body])
       end
+    end
 
-      context "自分の記事を更新するとき" do
-        let(:article) { create(:article, user: current_user) }
+    context "他のuserの記事を更新しようとるすとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
 
-        it "任意の記事の更新ができる" do
-          expect { subject }.to change { Article.find(article.id).title }.from(article.title).to(params[:article][:title]) &
-                                change { Article.find(article.id).body }.from(article.body).to(params[:article][:body])
-        end
-      end
-
-      context "他のuserの記事を更新しようとるすとき" do
-        let(:other_user) { create(:user) }
-        before(:article) { create(:article, user: other_user) }
-
-        it "更新できない" do
-          expect { subject }.to raise_error ActiveRecord::RecordNotFound &
-                                            change { Article.count }.by(0)
-        end
+      it "更新できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        change { Article.count }.by(0)
       end
     end
   end

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -97,5 +97,33 @@ RSpec.describe "Api::V1::Articles", type: :request do
         change { Article.count }.by(0)
       end
     end
+
+    describe "DELETE /articles/:id" do
+      subject { delete(api_v1_article_path(article_id)) }
+
+      # devise_token_auth の導入が完了後に削除
+      let(:current_user) { create(:user) }
+      let(:article_id) { article.id }
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+      context "自分の記事を削除しようとするとき" do
+        let!(:article) { create(:article, user: current_user) }
+
+        it "記事を削除できる" do
+          expect { subject }.to change { Article.count }.by(-1)
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+
+      context "他人が所持している記事のレコードを削除しようとするとき" do
+        let(:other_user) { create(:user) }
+        let!(:article) { create(:article, user: other_user) }
+
+        it "記事を削除できない" do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                                change { Article.count }.by(0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
- 記事の削除機能とテストを実装

## 補足
- 記事の更新機能実装の際にテストが正常に走っていなかったのでこの PR の中で修正