### PR TITLE
rubocop のルールの一部変更と annotate を実行

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,6 @@
 #  encrypted_password     :string           default(""), not null
 #  image                  :string
 #  name                   :string
-#  nickname               :string
 #  provider               :string           default("email"), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -72,3 +72,7 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+# context ごとに let! を使い分けたい場合があるため無効に
+RSpec/LetSetup:
+  Enabled: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,6 @@ ActiveRecord::Schema.define(version: 2020_07_02_125252) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "name"
-    t.string "nickname"
     t.string "image"
     t.string "email"
     t.json "tokens"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,7 +11,6 @@
 #  encrypted_password     :string           default(""), not null
 #  image                  :string
 #  name                   :string
-#  nickname               :string
 #  provider               :string           default("email"), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,6 @@
 #  encrypted_password     :string           default(""), not null
 #  image                  :string
 #  name                   :string
-#  nickname               :string
 #  provider               :string           default("email"), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime


### PR DESCRIPTION
## 概要
- rspec の `let`に関する記述を rubocop の監視対象から外して、ついでに`annotate`を実行する