### PR TITLE
CORS の設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "config"
 gem "devise_token_auth"
 gem "pg"
 gem "puma", "~> 3.11"
+gem 'rack-cors'
 gem "rails", "~> 6.0.3"
 gem "turbolinks", "~> 5"
 gem "webpacker"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "config"
 gem "devise_token_auth"
 gem "pg"
 gem "puma", "~> 3.11"
-gem 'rack-cors'
+gem "rack-cors"
 gem "rails", "~> 6.0.3"
 gem "turbolinks", "~> 5"
 gem "webpacker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
       pry (>= 0.10.4)
     puma (3.12.6)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -316,6 +318,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   puma (~> 3.11)
+  rack-cors
   rails (~> 6.0.3)
   rails-erd
   rspec-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,16 @@
+
+# Be sure to restart your server when you modify this file.
+
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+
+# Read more: https://github.com/cyu/rack-cors
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins Settings.frontend.url
+    resource "*",
+             headers: :any,
+             methods: [:get, :post, :put, :patch, :delete, :options]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,4 +1,3 @@
-
 # Be sure to restart your server when you modify this file.
 
 # Avoid CORS issues when API is called from the frontend app.

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+frontend:
+  url: "http://localhost:8080"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+frontend:
+  url: "http://localhost:8080"


### PR DESCRIPTION
## 概要
- フロントエンドからのアクセスを許可する為の設定

## 手順
1. https://github.com/keita-naito/wonderful_editor/pull/56 で導入した `Config` で作成したファイルに定数を書き込む
（ `config/settings/development.yml` & `config/settings/test.yml`)
2. Gemfile に `rack-cors` を追記して bundle install
3. Cors の設定を記述
（https://github.com/keita-naito/wonderful_editor/pull/60 の内容が最終的な設定内容になります）

## 補足
- Cors で設定したルールが雑で何でもオッケーになっているので、本来はしっかり絞りこむ必要があります。