### PR TITLE
node と yarn のバージョン指定を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "wonderful_editor",
+  "engines": {
+    "node": "15.X",
+    "yarn": "1.x"
+  },
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",


### PR DESCRIPTION
## 概要
- タイトルの通り

## 内容
- バージョンの指定をしないとデプロイした際に最新の node のバージョンが反映されてコケていたので調整。

## 補足
Heroku でデプロイする場合、ダッシュボードの Settings タブから Buildpacks の項目で node.js を追加して node.js を先頭に持ってくる必要がある。
（package.json で指定した内容が反映されないため）
